### PR TITLE
Use deploy script in vagrant file

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -2,7 +2,7 @@ $script = <<SCRIPT
 cd /var/www/sites/SciGraph-vagrant
 if [[ ! -d 'SciGraph' ]]
 then
-./deploy.sh -u
+./deploy.sh -u -g biologicalOntologies.yaml -r biologicalOntologiesConfiguration.yaml
 fi
 SCRIPT
 
@@ -23,6 +23,4 @@ Vagrant.configure("2") do |config|
   config.ssh.forward_agent  = true
   config.vm.network :private_network, ip: "10.33.36.99"
   config.vm.provision :shell, inline: $script
-  config.vm.provision :shell, inline: "cd #{path}/SciGraph/SciGraph-core; mvn exec:java -Dexec.mainClass=\"edu.sdsc.scigraph.owlapi.loader.BatchOwlLoader\" -Dexec.args=\"-c ../../build_configurations/biologicalOntologies.yaml\""
-  config.vm.provision :shell, inline: "cd #{path}/SciGraph/SciGraph-services; mvn exec:java -Dexec.mainClass=\"edu.sdsc.scigraph.services.MainApplication\" -Dexec.args=\"server ../../run_configurations/biologicalOntologiesConfiguration.yaml\""
 end

--- a/deploy.sh
+++ b/deploy.sh
@@ -48,8 +48,8 @@ function start_ontology_service(){
 		pushd SciGraph/SciGraph-services
 		if [[ -e ../../run_configurations/$1 ]]
 		then
-			mvn exec:java -Dexec.mainClass="edu.sdsc.scigraph.services.MainApplication" -Dexec.args="server ../../run_configurations/$1"
-      popd
+			screen mvn exec:java -Dexec.mainClass="edu.sdsc.scigraph.services.MainApplication" -Dexec.args="server ../../run_configurations/$1"
+      screen -d
 			#echo "running service from $1 configuration"
 		else
 			echo "$1 not found in run_configurations folder"

--- a/deploy.sh
+++ b/deploy.sh
@@ -53,8 +53,7 @@ function start_ontology_service(){
         echo "screen not found....installing screen"
         sudo apt-get install screen
       fi
-			screen mvn exec:java -Dexec.mainClass="edu.sdsc.scigraph.services.MainApplication" -Dexec.args="server ../../run_configurations/$1"
-      screen -d
+			screen -d -m mvn exec:java -Dexec.mainClass="edu.sdsc.scigraph.services.MainApplication" -Dexec.args="server ../../run_configurations/$1"
 			echo "The ontology server has been setup on a detached screen."
       echo "To get back to the terminal running the server process (for example if you which to stop the server) excute screen -r"
 		else

--- a/deploy.sh
+++ b/deploy.sh
@@ -48,9 +48,15 @@ function start_ontology_service(){
 		pushd SciGraph/SciGraph-services
 		if [[ -e ../../run_configurations/$1 ]]
 		then
+      if [[ -z "$(which screen)" ]]
+      then
+        echo "screen not found....installing screen"
+        sudo apt-get install screen
+      fi
 			screen mvn exec:java -Dexec.mainClass="edu.sdsc.scigraph.services.MainApplication" -Dexec.args="server ../../run_configurations/$1"
       screen -d
-			#echo "running service from $1 configuration"
+			echo "The ontology server has been setup on a detached screen."
+      echo "To get back to the terminal running the server process (for example if you which to stop the server) excute screen -r"
 		else
 			echo "$1 not found in run_configurations folder"
 			exit 1


### PR DESCRIPTION
1) Make vagrant box run using the deploy script for installing dependencies, installing graphs and starting ontology services

2) Run the ontology server in a screen in detached mode when using the deploy script