### PR TITLE
Moving curies out of configlp

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,9 +2,7 @@ SciGraph
 build_configurations/target/*/
 build_configurations/target/*/
 build_configurations/*.yaml.old
-build_configurations/*.yaml
 run_configurations/*.yaml.old
-run_configurations/*.yaml
 .vagrant
 ontologies/*.owl
 ontologies/*.ttl

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ to specify which ontologies you want to load into the Ontology store.
 
 At the heart of SciGraph-vagrant is the deploy.sh script.  This script 
 * reads the config.lp file 
-* downloads the necessary ontologies from the specified urls applying all the specified CURIES
+* checks for ontology updates and downloads the necessary ontologies from the specified urls
 * loads all the SciGraph dependencies by running mvn install
 * it will even go and clone/pull the latest updates from https://github.com/SciCrunch/SciGraph
 
@@ -58,7 +58,7 @@ Also please makes sure you stop the server before running the deploy script
 The config.pl file
 ------------------
 This file tells the deploy.sh script which ontologies to load and were to get them from.  The format is as follows
-`[full url to the ontology|url] [ontology filename|filename] [alias for CURIE|alias] [url for CURIE|url]`
+`[full url to the ontology|url] [ontology filename|filename]`
 
 Please follow the format that is in the default config.lp
 

--- a/build_configurations/biologicalOntologies.yaml
+++ b/build_configurations/biologicalOntologies.yaml
@@ -1,0 +1,59 @@
+graphConfiguration:
+    location: ../../build_configurations/target/biologicalOntologies
+    indexedNodeProperties:
+      - label
+      - fragment
+    exactNodeProperties:
+      - label
+      - synonym
+ontologies:
+  - url: ../../ontologies/hp.owl
+    reasonerConfiguration:
+      factory: org.semanticweb.elk.owlapi.ElkReasonerFactory
+  - url: ../../ontologies/doid.owl
+    reasonerConfiguration:
+      factory: org.semanticweb.elk.owlapi.ElkReasonerFactory
+  - url: ../../ontologies/MeSH.owl
+    reasonerConfiguration:
+      factory: org.semanticweb.elk.owlapi.ElkReasonerFactory
+  - url: ../../ontologies/obi.owl
+    reasonerConfiguration:
+      factory: org.semanticweb.elk.owlapi.ElkReasonerFactory
+  - url: ../../ontologies/go.owl
+    reasonerConfiguration:
+      factory: org.semanticweb.elk.owlapi.ElkReasonerFactory
+  - url: ../../ontologies/chebi.owl
+    reasonerConfiguration:
+      factory: org.semanticweb.elk.owlapi.ElkReasonerFactory
+  - url: ../../ontologies/so.owl
+    reasonerConfiguration:
+      factory: org.semanticweb.elk.owlapi.ElkReasonerFactory
+  - url: ../../ontologies/fma.owl
+    reasonerConfiguration:
+      factory: org.semanticweb.elk.owlapi.ElkReasonerFactory
+  - url: ../../ontologies/cl.owl
+    reasonerConfiguration:
+      factory: org.semanticweb.elk.owlapi.ElkReasonerFactory
+  - url: ../../ontologies/hugo.owl
+    reasonerConfiguration:
+      factory: org.semanticweb.elk.owlapi.ElkReasonerFactory
+  - url: ../../ontologies/OMIM.ttl
+    reasonerConfiguration:
+      factory: org.semanticweb.elk.owlapi.ElkReasonerFactory
+categories:
+    http://purl.obolibrary.org/obo/HP_0001909 : leukemia
+    http://purl.obolibrary.org/obo/HP_0001911 : granulocytes
+mappedProperties:
+  - name: label # The name of the new property
+    properties: # The list of properties mapped to the new property
+    - http://www.w3.org/2000/01/rdf-schema#label
+    - http://www.w3.org/2004/02/skos/core#prefLabel
+  - name: comment
+    properties:
+    - http://www.w3.org/2000/01/rdf-schema#comment
+  - name: synonym
+    properties:
+    - http://www.geneontology.org/formats/oboInOwl#hasExactSynonym
+    - http://purl.obolibrary.org/obo#Synonym
+    - http://purl.obolibrary.org/obo/go#systematic_synonym
+    - http://www.w3.org/2004/02/skos/core#altLabel

--- a/config.lp
+++ b/config.lp
@@ -1,11 +1,11 @@
-url|https://s3.amazonaws.com/ontologies-bucket/hp.owl ontology_name|hp.owl curie_alias|HP curie_path|http://purl.obolibrary.org/obo/HP_
-url|http://www.berkeleybop.org/ontologies/doid.owl ontology_name|doid.owl curie_alias|DOID curie_path|http://purl.obolibrary.org/obo/DOID_
-url|http://data.bioontology.org/ontologies/RH-MESH/submissions/3/download?apikey=8b5b7825-538d-40e0-9e9e-5ab9274a9aeb ontology_name|MeSH.owl curie_alias|MESH curie_path|http://phenomebrowser.net/ontologies/mesh/mesh.owl#
-url|http://svn.code.sf.net/p/obi/code/releases/2015-03-17/obi.owl ontology_name|obi.owl curie_alias|OBI curie_path|http://purl.obolibrary.org/obo/OBI_
-url|http://www.geneontology.org/ontology/go.owl ontology_name|go.owl curie_alias|GO curie_path|http://purl.obolibrary.org/obo/GO_
-url|ftp://ftp.ebi.ac.uk/pub/databases/chebi/ontology/chebi.owl ontology_name|chebi.owl curie_alias|CHEBI curie_path|http://purl.obolibrary.org/obo/CHEBI_
-url|http://www.berkeleybop.org/ontologies/so.owl ontology_name|so.owl curie_alias|SO curie_path|http://purl.obolibrary.org/obo/SO_
-url|http://www.berkeleybop.org/ontologies/fma.owl ontology_name|fma.owl curie_alias|FMA curie_path|http://purl.obolibrary.org/obo/FMA_
-url|http://cell-ontology.googlecode.com/svn/trunk/src/ontology/cl.owl ontology_name|cl.owl curie_alias|CL curie_path|http://purl.obolibrary.org/obo/CL_
-url|https://s3.amazonaws.com/ontologies-bucket/hugo.owl ontology_name|hugo.owl curie_alias|HUGO curie_path|http://ncicb.nci.nih.gov/xml/owl/EVS/Hugo.owl#
-url|https://s3.amazonaws.com/ontologies-bucket/OMIM.ttl ontology_name|OMIM.ttl curie_alias|OMIM curie_path|http://purl.bioontology.org/ontology/OMIM
+url|https://s3.amazonaws.com/ontologies-bucket/hp.owl ontology_name|hp.owl
+url|http://www.berkeleybop.org/ontologies/doid.owl ontology_name|doid.owl
+url|http://data.bioontology.org/ontologies/RH-MESH/submissions/3/download?apikey=8b5b7825-538d-40e0-9e9e-5ab9274a9aeb ontology_name|MeSH.owl
+url|http://svn.code.sf.net/p/obi/code/releases/2015-03-17/obi.owl ontology_name|obi.owl
+url|http://www.geneontology.org/ontology/go.owl ontology_name|go.owl
+url|ftp://ftp.ebi.ac.uk/pub/databases/chebi/ontology/chebi.owl ontology_name|chebi.owl
+url|http://www.berkeleybop.org/ontologies/so.owl ontology_name|so.owl
+url|http://www.berkeleybop.org/ontologies/fma.owl ontology_name|fma.owl
+url|http://cell-ontology.googlecode.com/svn/trunk/src/ontology/cl.owl ontology_name|cl.owl
+url|https://s3.amazonaws.com/ontologies-bucket/hugo.owl ontology_name|hugo.owl
+url|https://s3.amazonaws.com/ontologies-bucket/OMIM.ttl ontology_name|OMIM.ttl

--- a/deploy.sh
+++ b/deploy.sh
@@ -111,17 +111,17 @@ function initialize_scigraph_run_configuration_file(){
     echo '    - label'>>run_configurations/$1
     echo '    - synonym'>>run_configurations/$1
     echo '  curies:'>>run_configurations/$1
-    echo "    'HP': 'http://purl.obolibrary.org/obo/HP_'"
-    echo "    'DOID': 'http://purl.obolibrary.org/obo/DOID_'"
-    echo "    'MESH': 'http://phenomebrowser.net/ontologies/mesh/mesh.owl#'"
-    echo "    'OBI': 'http://purl.obolibrary.org/obo/OBI_'"
-    echo "    'GO': 'http://purl.obolibrary.org/obo/GO_'"
-    echo "    'CHEBI': 'http://purl.obolibrary.org/obo/CHEBI_'"
-    echo "    'SO': 'http://purl.obolibrary.org/obo/SO_'"
-    echo "    'FMA': 'http://purl.obolibrary.org/obo/FMA_'"
-    echo "    'CL': 'http://purl.obolibrary.org/obo/CL_'"
-    echo "    'HUGO': 'http://ncicb.nci.nih.gov/xml/owl/EVS/Hugo.owl#'"
-    echo "    'OMIM': 'http://purl.bioontology.org/ontology/OMIM'"
+    echo "    'HP': 'http://purl.obolibrary.org/obo/HP_'" >> run_configurations/$1
+    echo "    'DOID': 'http://purl.obolibrary.org/obo/DOID_'" >> run_configurations/$1
+    echo "    'MESH': 'http://phenomebrowser.net/ontologies/mesh/mesh.owl#'" >> run_configurations/$1
+    echo "    'OBI': 'http://purl.obolibrary.org/obo/OBI_'" >> run_configurations/$1
+    echo "    'GO': 'http://purl.obolibrary.org/obo/GO_'" >> run_configurations/$1
+    echo "    'CHEBI': 'http://purl.obolibrary.org/obo/CHEBI_'" >> run_configurations/$1
+    echo "    'SO': 'http://purl.obolibrary.org/obo/SO_'" >> run_configurations/$1
+    echo "    'FMA': 'http://purl.obolibrary.org/obo/FMA_'" >> run_configurations/$1
+    echo "    'CL': 'http://purl.obolibrary.org/obo/CL_'" >> run_configurations/$1
+    echo "    'HUGO': 'http://ncicb.nci.nih.gov/xml/owl/EVS/Hugo.owl#'" >> run_configurations/$1
+    echo "    'OMIM': 'http://purl.bioontology.org/ontology/OMIM'" >> run_configurations/$1
   fi
 }
 

--- a/deploy.sh
+++ b/deploy.sh
@@ -111,6 +111,17 @@ function initialize_scigraph_run_configuration_file(){
     echo '    - label'>>run_configurations/$1
     echo '    - synonym'>>run_configurations/$1
     echo '  curies:'>>run_configurations/$1
+    echo "    'HP': 'http://purl.obolibrary.org/obo/HP_'"
+    echo "    'DOID': 'http://purl.obolibrary.org/obo/DOID_'"
+    echo "    'MESH': 'http://phenomebrowser.net/ontologies/mesh/mesh.owl#'"
+    echo "    'OBI': 'http://purl.obolibrary.org/obo/OBI_'"
+    echo "    'GO': 'http://purl.obolibrary.org/obo/GO_'"
+    echo "    'CHEBI': 'http://purl.obolibrary.org/obo/CHEBI_'"
+    echo "    'SO': 'http://purl.obolibrary.org/obo/SO_'"
+    echo "    'FMA': 'http://purl.obolibrary.org/obo/FMA_'"
+    echo "    'CL': 'http://purl.obolibrary.org/obo/CL_'"
+    echo "    'HUGO': 'http://ncicb.nci.nih.gov/xml/owl/EVS/Hugo.owl#'"
+    echo "    'OMIM': 'http://purl.bioontology.org/ontology/OMIM'"
   fi
 }
 
@@ -265,10 +276,6 @@ function get_ontologies_config_file_parser(){
                ;;
             1) ontology_file_name=$ontology_key_value_pair
                ;;
-            2) ontology_curie_alias=$ontology_key_value_pair
-               ;;
-            3) ontology_curie_url=$ontology_key_value_pair
-               ;;
           esac
           #configuration_array[$currentcolumn, $currentrow]=$ontology_key_value_pair
 
@@ -282,8 +289,8 @@ function get_ontologies_config_file_parser(){
     done
     download_ontology_file $ontology_url $ontology_file_name
     insert_scigraph_graph_ontology $1 $ontology_file_name
-    insert_scigraph_graph_curries ${filename%.yaml}Configuration.yaml $ontology_curie_alias $ontology_curie_url
 
+    #insert_scigraph_graph_curries ${filename%.yaml}Configuration.yaml $ontology_curie_alias $ontology_curie_url
     #process_ontology_configuration $1 $ontology_url $ontology_file_name $ontology_curie_alias $ontology_curie_url
     #currentrow=$((currentrow+1))
   done < config.lp

--- a/run_configurations/biologicalOntologiesConfiguration.yaml
+++ b/run_configurations/biologicalOntologiesConfiguration.yaml
@@ -1,0 +1,41 @@
+server:
+  type: simple
+  applicationContextPath: /scigraph
+  adminContextPath: /admin
+  connector:
+    type: http
+    port: 9000
+logging:
+  level: INFO
+graphConfiguration:
+  location: ../../build_configurations/target/biologicalOntologies
+  indexedNodeProperties:
+    - label
+    - fragment
+  exactNodeProperties:
+    - label
+    - synonym
+  curies:
+    'HP': 'http://purl.obolibrary.org/obo/HP_'
+    'DOID': 'http://purl.obolibrary.org/obo/DOID_'
+    'MESH': 'http://phenomebrowser.net/ontologies/mesh/mesh.owl#'
+    'OBI': 'http://purl.obolibrary.org/obo/OBI_'
+    'GO': 'http://purl.obolibrary.org/obo/GO_'
+    'CHEBI': 'http://purl.obolibrary.org/obo/CHEBI_'
+    'SO': 'http://purl.obolibrary.org/obo/SO_'
+    'FMA': 'http://purl.obolibrary.org/obo/FMA_'
+    'CL': 'http://purl.obolibrary.org/obo/CL_'
+    'HUGO': 'http://ncicb.nci.nih.gov/xml/owl/EVS/Hugo.owl#'
+    'OMIM': 'http://purl.bioontology.org/ontology/OMIM'
+serviceMetadata:
+  name: 'Pizza Reconciliation Service'
+  identifierSpace: 'http://example.org'
+  schemaSpace: 'http://example.org'
+  view: {
+    url: 'http://localhost:9000/scigraph/refine/view/{{id}}'
+  }
+  preview: {
+    url: 'http://localhost:9000/scigraph/refine/preview/{{id}}',
+    width: 400,
+    height: 400
+  }


### PR DESCRIPTION
We are moving the curies out of the config.lp workflow.  We have made the configuration yaml files part of the repository so you can put in additional curies and synonyms in them.  We are still retaining the ability to generate the configuration files in the deploy script with a default setup so that you can create easily setup a new config file when needed.